### PR TITLE
[feature/domain] 도메인 1차 작업으로 Card 도메인과 Note 도메인 연결 작업 진행하였습니다

### DIFF
--- a/src/main/java/com/Thethirdtool/backend/BackendApplication.java
+++ b/src/main/java/com/Thethirdtool/backend/BackendApplication.java
@@ -2,7 +2,10 @@ package com.Thethirdtool.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
@@ -1,0 +1,28 @@
+package com.Thethirdtool.backend.Card.domain;
+
+
+import com.Thethirdtool.backend.common.jpa.AuditingField;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+@Entity
+public class Card extends AuditingField {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "note_id")
+    private Note note;
+
+
+}

--- a/src/main/java/com/Thethirdtool/backend/Note/domain/Note.java
+++ b/src/main/java/com/Thethirdtool/backend/Note/domain/Note.java
@@ -1,0 +1,30 @@
+package com.Thethirdtool.backend.Note.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Note {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 1000)
+    private String question; // 문제
+
+    @Column(nullable = false, length = 1000)
+    private String answer; // 정답
+
+    private Instant mtime;
+
+    private int usn;
+}

--- a/src/main/java/com/Thethirdtool/backend/common/jpa/AuditingField.java
+++ b/src/main/java/com/Thethirdtool/backend/common/jpa/AuditingField.java
@@ -1,0 +1,24 @@
+package com.Thethirdtool.backend.common.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class AuditingField {
+
+    @CreatedDate
+    @Column(updatable = false)
+    protected Instant createdAt;
+
+    @LastModifiedDate
+    protected Instant modifiedAt;
+}


### PR DESCRIPTION
## ✨ 작업 내용

- `Note`, `Card` 엔티티 및 `AuditingField` 공통 필드 설계
- `Note`는 문제(question)와 정답(answer), 수정 시간(mtime), 동기화 번호(usn)를 포함
- `Card`는 `Note`와 연관 관계를 맺으며, 콘텐츠(content)를 보유
- 공통 필드인 `createdAt`, `modifiedAt`은 `AuditingField`를 통해 상속 처리

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요? (`feature/domain`)
- [x] Label을 지정했나요? (`domain`, `entity`, `initial-setup` 등)

## 🎃 새롭게 알게된 사항

- `@MappedSuperclass`를 사용해 여러 엔티티에 공통된 필드를 효율적으로 상속할 수 있음
- `@EntityListeners(AuditingEntityListener.class)`와 `@CreatedDate`, `@LastModifiedDate`를 통해 자동 시간 기록이 가능함
- Builder 패턴을 통해 불변 객체 스타일로 엔티티 생성이 가능하고, 테스트 시 객체 조립이 편리함

## 📋 참고 사항

- 이 PR은 프로젝트의 도메인 초기 설계에 해당하며, `Note`, `Card`, `AuditingField` 중심으로 구성되었습니다.
- 이후 이 구조를 기반으로 `Deck`, `Tag`, `Schedule` 등의 연관 도메인이 추가될 예정입니다.
- 현재 테스트 코드는 포함되지 않았으므로, 병합 전 단위 테스트 작성 필요
