### PR TITLE
Feature/domain - Card Deck 도메인 추가 설정하였습니다!

### DIFF
--- a/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
@@ -1,6 +1,8 @@
 package com.Thethirdtool.backend.Card.domain;
 
 
+import com.Thethirdtool.backend.Deck.domain.Deck;
+import com.Thethirdtool.backend.Note.domain.Note;
 import com.Thethirdtool.backend.common.jpa.AuditingField;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -23,6 +25,10 @@ public class Card extends AuditingField {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "note_id")
     private Note note;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "deck_id")
+    private Deck deck;
 
 
 }

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
@@ -48,6 +48,96 @@ public class Card extends AuditingField {
     private DuePeriod duePeriod;
 
 
+    // ====== 학습 로직 ======
+
+    public void archive() {
+        this.isArchived = true;
+        this.dueDate = null;
+        this.intervalDays = 0;
+    }
+
+
+    //3day에서 제공하는 4개의 블록 중 하나-> 3day로 복귀하자 permanent용
+    public void restoreToGeneralStudy() {
+        this.isArchived = false;
+        this.intervalDays = 1;
+        this.dueDate = Instant.now().plusSeconds(86400L);
+    }
+    //3day에서 제공하는 4개의 블록 중 하나
+    public void successReview() {
+        this.reps += 1;
+        this.successCount += 1;
+
+        if (successCount == 1) intervalDays += 1;
+        else if (successCount == 2) intervalDays += 2;
+        else if (successCount == 3) intervalDays += 3;
+        else intervalDays *= 2;
+
+        this.dueDate = Instant.now().plusSeconds(intervalDays * 86400L);
+
+        if (intervalDays > 30) {
+            archive(); // 영구 저장소로 이동
+        }
+    }
+    // success 수준 slow 버전
+    public void successReviewSlow() {
+        this.reps += 1;
+        this.successCount += 1;
+
+        if (intervalDays <= 3) {
+            intervalDays += 1; // 처음엔 조금만 증가
+        } else if (intervalDays <= 10) {
+            intervalDays += 2; // 약간씩 증가
+        } else if (intervalDays <= 20) {
+            intervalDays += 3; // 여전히 점진적으로
+        } else {
+            intervalDays = (int) (intervalDays * 1.2); // 완만한 곱셈 증가
+        }
+
+        this.dueDate = Instant.now().plusSeconds(intervalDays * 86400L);
+
+        if (intervalDays > 30) {
+            archive(); // 영구 덱으로 전환
+        }
+    }
+    // 3day에서 제공하는 4개의 블록 중 하나 -> 우선 3개라고 하자구 ㅎ
+    public void failReview(float lapseMultiplier) {
+        this.successCount = 0;
+        this.lapses += 1;
+        this.easeFactor = (int) (this.easeFactor * lapseMultiplier);
+        this.dueDate = Instant.now().plusSeconds(10 * 60); // 10분 후 복습
+    }
+    //interval days 유지하고 계속 dueDate만 미루기
+    public void refreshDueDate() {
+        this.dueDate = Instant.now().plusSeconds(intervalDays * 86400L);
+    }
+
+
+    // permanent 프로젝트에서 선택된 due 그룹에 따라 초기화 permanent 버튼 중 하나
+    public void resetDueGroup(String selectedGroup) {
+        if (selectedGroup.equals("stay")) {
+            keepCurrentDue(); // 아무 것도 하지 않음
+            return;
+        }
+
+        int newInterval = switch (selectedGroup) {
+            case "3day" -> 3;
+            case "1week" -> 7;
+            case "2week" -> 14;
+            default -> throw new IllegalArgumentException("잘못된 그룹 선택");
+        };
+
+        this.isArchived = false;
+        this.intervalDays = newInterval;
+        this.dueDate = Instant.now().plusSeconds(newInterval * 86400L);
+    }
+
+    // 유지하기 (dueDate를 그대로 유지)- permanent에 그대로 잇기
+    public void keepCurrentDue() {
+        // 아무 작업도 하지 않음
+    }
+
+
 
 
 

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.Instant;
+
 @Getter
 @RequiredArgsConstructor
 @Builder
@@ -29,6 +31,24 @@ public class Card extends AuditingField {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "deck_id")
     private Deck deck;
+
+    @Column(name = "due_date")
+    private Instant dueDate;
+
+    private int intervalDays; //다음 복습까지 간격을 알려주는데 사용
+    private boolean isArchived;
+    private int successCount;
+    //복습을 성공하든 실패하든 복습한 횟수
+    private int reps;
+    private int easeFactor;
+    //📌 "카드를 외우는 데 실패한 횟수"
+    private int lapses;
+
+    @Enumerated(EnumType.STRING)
+    private DuePeriod duePeriod;
+
+
+
 
 
 }

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/DuePeriod.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/DuePeriod.java
@@ -1,0 +1,29 @@
+package com.Thethirdtool.backend.Card.domain;
+
+public enum DuePeriod {
+    D3(0, 3),
+    WEEK1(4, 7),
+    WEEK2(8, 14),
+    MONTH1(15, 30);
+
+    private final int min;
+    private final int max;
+
+    DuePeriod(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public int min() { return min; }
+    public int max() { return max; }
+
+    public static DuePeriod fromString(String period) {
+        return switch (period) {
+            case "3day" -> D3;
+            case "1week" -> WEEK1;
+            case "2week" -> WEEK2;
+            case "1month" -> MONTH1;
+            default -> throw new IllegalArgumentException("잘못된 기간 선택입니다.");
+        };
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/CardBehvior.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/CardBehvior.java
@@ -1,0 +1,4 @@
+package com.Thethirdtool.backend.Card.domain.StudyPolicy;
+
+public interface CardBehvior {
+}

--- a/src/main/java/com/Thethirdtool/backend/Deck/domain/Deck.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/domain/Deck.java
@@ -1,0 +1,50 @@
+package com.Thethirdtool.backend.Deck.domain;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Deck {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "deck", fetch = FetchType.LAZY)
+    private List<Card> cards = new ArrayList<>();
+
+    @Column(nullable = false)
+    private boolean isFrozen = false;
+
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Deck parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Deck> children = new ArrayList<>();
+
+
+    public boolean isRoot() {
+        return this.parent == null;
+    }
+
+    public void freeze() {
+        this.isFrozen = true;
+    }
+
+    public void unfreeze() {
+        this.isFrozen = false;
+    }
+
+
+}


### PR DESCRIPTION
## ✨ 작업 내용

- `Card` 도메인에 학습 상태 관련 속성과 로직 추가 (`dueDate`, `intervalDays`, `successCount`, `lapses` 등)
- `Card` 클래스에 3day 학습 주기에 맞춘 `successReview`, `failReview`, `successReviewSlow`, `archive`, `restoreToGeneralStudy` 등의 복습 로직 구현
- `Card`의 상태 분류를 위한 `DuePeriod` enum 설계 (3day, 1week, 2week, 1month)
- `Deck` 도메인에 계층형 구조(자식 Deck) 설계 및 freeze/unfreeze 기능 추가

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요? (`feature/domain`)
- [x] Label을 지정했나요? (`domain`, `learning-logic`, `card-deck-structure` 등)

## 🎃 새롭게 알게된 사항

- 복습 주기를 조절하는 `intervalDays`와 `dueDate`를 기반으로 다양한 학습 전략을 코드로 구현할 수 있음
- `Card`의 성공/실패/보류 같은 행동을 메서드로 구분하여 향후 전략 패턴 또는 상태 패턴 적용이 쉬움
- `Deck`은 계층 구조를 지원하며, 하나의 루트 덱 아래 여러 개의 자식 덱을 구성할 수 있음

## 📋 참고 사항

- 현재 로직은 3day 기반 복습 주기만을 고려하고 있으며, 추후 FSRS 등의 알고리즘 도입을 고려하고 있음
- `successReviewSlow()`는 학습 속도를 늦추는 사용자 맞춤 전략으로 도입됨
- `resetDueGroup()`은 영구 학습 모드에서 학습 주기 그룹을 수동으로 재설정하기 위한 기능임
- 테스트 코드 작성은 추후 학습 흐름 기반 테스트 케이스 수립 후 진행 예정입니다
