### PR TITLE
[feature/domain] Card behavior 카드 관련 학습 로직 -> strategy 패턴으로 분리하였습니다.

### DIFF
--- a/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/CardBehavior.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/CardBehavior.java
@@ -1,0 +1,16 @@
+package com.Thethirdtool.backend.Card.domain.StudyPolicy;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+import com.Thethirdtool.backend.Card.domain.StudyResult;
+
+import java.util.Map;
+
+public interface CardBehavior {
+    void processStudyResult(Card card, StudyResult result);
+    void resetDueGroup(Card card, String groupName);
+
+    /**
+     * 학습 결과에 따른 간격 예측
+     */
+    Map<String, String> previewIntervals(Card card);
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/CardBehaviorFactory.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/CardBehaviorFactory.java
@@ -1,0 +1,13 @@
+package com.Thethirdtool.backend.Card.domain.StudyPolicy;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+
+public class CardBehaviorFactory {
+
+    private static final CardBehavior THREE_DAY = new ThreeDayCardBehavior();
+    private static final CardBehavior PERMANENT = new PermanentCardBehavior();
+
+    public static CardBehavior from(Card card) {
+        return card.isArchived() ? PERMANENT : THREE_DAY;
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/CardBehvior.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/CardBehvior.java
@@ -1,4 +1,0 @@
-package com.Thethirdtool.backend.Card.domain.StudyPolicy;
-
-public interface CardBehvior {
-}

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/PermanentCardBehavior.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/PermanentCardBehavior.java
@@ -1,0 +1,47 @@
+package com.Thethirdtool.backend.Card.domain.StudyPolicy;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+import com.Thethirdtool.backend.Card.domain.StudyResult;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class PermanentCardBehavior implements CardBehavior {
+
+    @Override
+    public void processStudyResult(Card card, StudyResult result) {
+        // Permanent에서는 study 결과 반영 안함 → No-op
+    }
+
+    @Override
+    public void resetDueGroup(Card card, String groupName) {
+        if (groupName == null || groupName.isBlank()) {
+            card.keepCurrentDue(); // 유지
+            return;
+        }
+
+        switch (groupName) {
+            case "3day", "1week", "2week", "stay" -> card.resetDueGroup(groupName);
+            default -> throw new IllegalArgumentException("잘못된 그룹 선택: " + groupName);
+        }
+    }
+
+    @Override
+    public Map<String, String> previewIntervals(Card card) {
+        Map<String, String> preview = new LinkedHashMap<>();
+
+        // STAY: 현재 interval 유지
+        preview.put("STAY", card.getIntervalDays() + "일 유지");
+
+        // 3DAY
+        preview.put("3day", "3day로 복귀");
+
+        // 1WEEK
+        preview.put("1week", "1week로 복귀");
+
+        // 2WEEK
+        preview.put("2week", "2week로 복귀");
+
+        return preview;
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/ThreeDayCardBehavior.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/StudyPolicy/ThreeDayCardBehavior.java
@@ -1,0 +1,56 @@
+package com.Thethirdtool.backend.Card.domain.StudyPolicy;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+import com.Thethirdtool.backend.Card.domain.StudyResult;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ThreeDayCardBehavior implements CardBehavior {
+
+    @Override
+    public void processStudyResult(Card card, StudyResult result) {
+        switch (result) {
+            case AGAIN -> card.failReview(0.8f); // 실패 시 간격 축소
+            case NORMAL -> card.successReviewSlow(); // 보통: 일반 복습으로 리셋 ->
+            case GOOD -> card.successReview(); // 성공 시 간격 증가
+            case STAY -> card.refreshDueDate();
+        }
+    }
+
+    @Override
+    public void resetDueGroup(Card card, String groupName) {
+        // 3day에선 resetGroup은 쓰지 않을 수 있음 → No-op 또는 예외
+    }
+    @Override
+    public Map<String, String> previewIntervals(Card card) {
+        Map<String, String> preview = new LinkedHashMap<>();
+
+        int interval = card.getIntervalDays();
+        int successCount = card.getSuccessCount();
+
+        // GOOD
+        int nextGood;
+        if (successCount == 0) nextGood = interval + 1;
+        else if (successCount == 1) nextGood = interval + 2;
+        else if (successCount == 2) nextGood = interval + 3;
+        else nextGood = interval * 2;
+        preview.put("GOOD", nextGood + "일 후");
+
+        // NORMAL
+        int nextNormal;
+        if (interval <= 3) nextNormal = interval + 1;
+        else if (interval <= 10) nextNormal = interval + 2;
+        else if (interval <= 20) nextNormal = interval + 3;
+        else nextNormal = (int)(interval * 1.2);
+        preview.put("NORMAL", nextNormal + "일 후");
+
+        // AGAIN
+        preview.put("AGAIN", "10분 후");
+
+        // STAY
+        preview.put("STAY", interval + "일 유지");
+
+        return preview;
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/StudyResult.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/StudyResult.java
@@ -1,0 +1,8 @@
+package com.Thethirdtool.backend.Card.domain;
+
+public enum StudyResult {
+    AGAIN,      // 다시 학습 (failReview)-> fail로 치는 데
+    NORMAL,     // 일반 복습 (restoreToGeneralStudy)
+    GOOD,        // 성공 복습 (successReview)
+    STAY         //  그냥 이대로 가자
+}


### PR DESCRIPTION
## ✨ 작업 내용

- 카드의 학습 전략을 유연하게 처리하기 위해 **Strategy 패턴**을 적용한 `CardBehavior` 인터페이스 도입
- `ThreeDayCardBehavior`와 `PermanentCardBehavior` 구현체를 통해, 일반 학습 카드와 영구 저장 카드의 행동 분리
- `CardBehaviorFactory`를 통해 카드 상태(`isArchived`)에 따라 적절한 전략을 반환하도록 구성
- 학습 결과에 따라 카드에 다양한 학습 반응을 적용 (`processStudyResult`)
- 사용자에게 학습 선택지를 제시할 수 있도록 `previewIntervals()` 로직 구현

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요? (`feature/domain`)
- [x] Label을 지정했나요? (`strategy-pattern`, `learning-logic`, `card-behavior` 등)

## 🎃 새롭게 알게된 사항

- 카드의 상태(예: 일반 학습 카드 vs. 영구 보관 카드)에 따라 다른 전략을 적용할 수 있게 되면, 조건문 분기가 줄고 코드의 응집도가 향상됨
- `Strategy Pattern`은 학습 결과별 분기 로직(`switch`)을 객체 수준에서 관리할 수 있게 해주어, 로직 테스트나 확장이 용이함
- `previewIntervals()`를 통해 사용자에게 학습 전략을 시각적으로 안내할 수 있는 UX 기반이 마련됨

## 📋 참고 사항

- 현재 `ThreeDayCardBehavior`는 3day 학습 흐름에 최적화된 로직이며, 추후 FSRS 알고리즘 또는 사용자 커스텀 학습 전략 추가 시 쉽게 확장 가능
- `PermanentCardBehavior`는 실제 복습 로직을 적용하지 않으며, 사용자가 선택한 그룹에 따라 상태를 설정하는 데만 사용됨
- 단위 테스트는 이후 `CardBehavior`의 각 구현체에 대해 전략 적용 여부와 결과값 예측을 중심으로 작성 예정