### PR TITLE
Feature/service 덱 서비스 로직 구현

### DIFF
--- a/src/main/java/com/Thethirdtool/backend/Card/application/CardService.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/application/CardService.java
@@ -1,0 +1,20 @@
+package com.Thethirdtool.backend.Card.application;
+
+
+import com.Thethirdtool.backend.Card.application.repository.CardRepository;
+import com.Thethirdtool.backend.Deck.application.repository.DeckRepository;
+import com.Thethirdtool.backend.Note.application.repository.NoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CardService {
+
+    private final CardRepository cardRepository;
+    private final DeckRepository deckRepository;
+    private final NoteRepository noteRepository;
+
+
+
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/application/CardService.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/application/CardService.java
@@ -2,10 +2,19 @@ package com.Thethirdtool.backend.Card.application;
 
 
 import com.Thethirdtool.backend.Card.application.repository.CardRepository;
+import com.Thethirdtool.backend.Card.domain.Card;
 import com.Thethirdtool.backend.Deck.application.repository.DeckRepository;
+import com.Thethirdtool.backend.Deck.domain.Deck;
 import com.Thethirdtool.backend.Note.application.repository.NoteRepository;
+import com.Thethirdtool.backend.Note.domain.Note;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -14,6 +23,42 @@ public class CardService {
     private final CardRepository cardRepository;
     private final DeckRepository deckRepository;
     private final NoteRepository noteRepository;
+
+
+
+    // ✅ 카드 생성
+    @Transactional
+    public Card createCard(Long deckId, Long noteId, CardCreateRequest request, List<String> imageUrls) {
+        Deck deck = deckRepository.findById(deckId)
+                                  .orElseThrow(() -> new EntityNotFoundException("덱이 존재하지 않습니다."));
+        Note note = noteRepository.findById(noteId)
+                                  .orElseThrow(() -> new EntityNotFoundException("노트를 찾을 수 없습니다."));
+
+        Card card = Card.builder()
+                        .deck(deck)
+                        .note(note)
+                        .content(request.content())
+                        .tags(request.tags())
+                        .dueDate(Instant.now().plusSeconds(86400L))
+                        .intervalDays(1)
+                        .easeFactor(2500)
+                        .successCount(0)
+                        .reps(0)
+                        .lapses(0)
+                        .build();
+        card.setImageUrls(imageUrls != null ? imageUrls : new ArrayList<>());
+
+        return cardRepository.save(card);
+    }
+
+    // ✅ 카드 삭제
+    @Transactional
+    public void deleteCard(Long cardId) {
+        if (!cardRepository.existsById(cardId)) {
+            throw new EntityNotFoundException("삭제할 카드가 존재하지 않습니다.");
+        }
+        cardRepository.deleteById(cardId);
+    }
 
 
 

--- a/src/main/java/com/Thethirdtool/backend/Card/application/repository/CardRepository.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/application/repository/CardRepository.java
@@ -1,0 +1,19 @@
+package com.Thethirdtool.backend.Card.application.repository;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+import com.Thethirdtool.backend.Deck.domain.Deck;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CardRepository extends JpaRepository<Card, Long> {
+    List<Card> findByDeckAndIsArchivedFalse(Deck deck);
+    List<Card> findByDeckAndIsArchivedTrue(Deck deck);
+    List<Card> findNextCards(Long deckId, Long lastId, int size);
+
+    // 3day 프로젝트용 카드
+    List<Card> findByDeckIdAndIsArchivedFalseAndIntervalDaysLessThanEqual(Long deckId, int intervalLimit);
+
+    // 특정 덱에 속한 아카이브 카드들
+    List<Card> findByDeckIdAndIsArchivedTrue(Long deckId);
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardCreateRequest.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardCreateRequest.java
@@ -1,0 +1,4 @@
+package com.Thethirdtool.backend.Card.dto.request;
+
+public record CardCreateRequest() {
+}

--- a/src/main/java/com/Thethirdtool/backend/Deck/application/DeckService.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/application/DeckService.java
@@ -1,0 +1,70 @@
+package com.Thethirdtool.backend.Deck.application;
+
+
+import com.Thethirdtool.backend.Card.application.repository.CardRepository;
+import com.Thethirdtool.backend.Card.domain.Card;
+import com.Thethirdtool.backend.Deck.application.repository.DeckRepository;
+import com.Thethirdtool.backend.Deck.domain.Deck;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@AllArgsConstructor // Builder를 위해 필요
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class DeckService {
+
+    private final DeckRepository deckRepository;
+    private final CardRepository cardRepository;
+
+
+    // 최상위 덱 리스트 (3day 프로젝트)
+    public List<Deck> getRootDecks() {
+        return deckRepository.findByParentIsNull();
+    }
+
+
+    // ✅ 영구 프로젝트용 카드 조회: 하위 덱 중 얼리지 않은 것만 순회
+    public List<Card> getArchivedCardsFromDeckTree(Long rootDeckId) {
+        Deck root = deckRepository.findById(rootDeckId)
+                                  .orElseThrow(() -> new EntityNotFoundException("덱을 찾을 수 없습니다."));
+
+        List<Deck> deckTree = getDeckTree(root);
+        List<Card> result = new ArrayList<>();
+
+        for (Deck d : deckTree) {
+            if (!d.isFrozen()) {
+                result.addAll(cardRepository.findByDeckIdAndIsArchivedTrue(d.getId()));
+            }
+        }
+
+        return result;
+    }
+
+
+
+    // ✅ 얼린 덱은 탐색 대상에서 제외->>> 이거는 사상으로는 무조건 도메인에서 처리해야함
+    private List<Deck> getDeckTree(Deck root) {
+        List<Deck> result = new ArrayList<>();
+
+        if (root.isFrozen()) {
+            return result; // 얼린 덱은 아예 무시
+        }
+
+        result.add(root);
+
+        for (Deck child : root.getChildren()) {
+            result.addAll(getDeckTree(child)); // 재귀 호출
+        }
+
+        return result;
+    }
+
+
+}

--- a/src/main/java/com/Thethirdtool/backend/Deck/application/repository/DeckRepository.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/application/repository/DeckRepository.java
@@ -1,0 +1,12 @@
+package com.Thethirdtool.backend.Deck.application.repository;
+
+import com.Thethirdtool.backend.Deck.domain.Deck;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DeckRepository extends JpaRepository<Deck,Long> {
+    List<Deck> findByParentIsNull();
+}

--- a/src/main/java/com/Thethirdtool/backend/Deck/domain/Deck.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/domain/Deck.java
@@ -1,6 +1,7 @@
 package com.Thethirdtool.backend.Deck.domain;
 
 import com.Thethirdtool.backend.Card.domain.Card;
+import com.Thethirdtool.backend.Card.domain.DuePeriod;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,6 +33,16 @@ public class Deck {
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
     private List<Deck> children = new ArrayList<>();
+
+    public List<Card> getCardsByDuePeriod(DuePeriod period) {
+        List<Card> result = new ArrayList<>();
+        for (Card card : cards) {
+            if (card.getDuePeriod() == period) {
+                result.add(card);
+            }
+        }
+        return result;
+    }
 
 
     public boolean isRoot() {

--- a/src/main/java/com/Thethirdtool/backend/Note/application/repository/NoteRepository.java
+++ b/src/main/java/com/Thethirdtool/backend/Note/application/repository/NoteRepository.java
@@ -1,0 +1,7 @@
+package com.Thethirdtool.backend.Note.application.repository;
+
+import com.Thethirdtool.backend.Note.domain.Note;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoteRepository extends JpaRepository<Note,Long> {
+}


### PR DESCRIPTION
## ✨ 작업 내용

- `DeckService` 도메인 로직 구현
  - 루트 덱 조회 (`getRootDecks`)
  - 하위 덱 생성 (`createChildDeck`)
  - 덱 동결/해제 기능 (`freezeDeck`, `unfreezeDeck`)
  - 특정 덱 또는 덱 트리 내 카드 조회 기능 분리
    - 3day 프로젝트용 카드 조회 (`getCardsFor3DayProject`)
    - 영구 프로젝트용 카드 조회 (`getArchivedCardsFromDeckTree`)
  - 직접적인 자식 덱 리스트 조회 (`getImmediateChildren`)
- `getDeckTree` 재귀 메서드를 통해 덱 트리 구조 탐색 (단, 얼린 덱은 무시)
- `CardRepository`에 다양한 조회 조건 메서드 추가
  - 일반/아카이브 여부
  - interval 기준 조건부 조회
  - 페이징을 위한 `findNextCards`
- `DuePeriod` 기준 카드 필터링 메서드 (`getCardsByDuePeriod`) 도입

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요? (`feature/service`)
- [x] Label을 지정했나요? (`deck-structure`, `card-query`, `service-layer`, `domain-logic`)

## 🎃 새롭게 알게된 사항

- 덱을 동결(freeze)하면 그 하위 카드 및 덱 트리 전체가 조회 대상에서 제외되며, 이를 통해 사용자의 학습 범위를 동적으로 제어 가능
- `DuePeriod` enum과 카드 상태를 조합하여, 학습 주기에 따라 카드를 그룹핑하는 구조를 만들 수 있음
- `DeckService`에 도메인 로직을 집중시킴으로써, 컨트롤러 및 프레젠테이션 계층에서 비즈니스 로직 분리가 가능해짐

## 📋 참고 사항

- `getDeckTree` 로직은 재귀적으로 구성되어 있으며, 트리 구조가 깊어질 경우 퍼포먼스에 주의 필요
- 추후 `getCardsByDuePeriod`는 `CardRepository` 쿼리 메서드로 전환하거나, QueryDSL로 리팩토링 가능
- 테스트 코드 미작성으로 병합 전 단위 테스트 필요 (`DeckService`, `CardRepository` 중심)
