### PR TITLE
Feature/service -> (주) 카드 서비스 레이어 로직 만들었습니다!

### DIFF
--- a/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
@@ -155,6 +155,19 @@ public class Card extends AuditingField {
     }
 
 
+    // 카드 업데이트 관련 로직
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateDeck(Deck deck) {
+        this.deck = deck;
+    }
+
+    public void updateNote(Note note) {
+        this.note = note;
+    }
+
 
 
 

--- a/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardUpdateRequest.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.Thethirdtool.backend.Card.dto.request;
+
+public record CardUpdateRequest() {
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardUpdateRequest.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardUpdateRequest.java
@@ -1,4 +1,12 @@
 package com.Thethirdtool.backend.Card.dto.request;
 
-public record CardUpdateRequest() {
-}
+import jakarta.validation.constraints.Size;
+
+public record CardUpdateRequest(
+        Long deckId,
+
+        Long noteId,
+
+        @Size(max = 1000, message = "카드 내용은 1000자를 초과할 수 없습니다.")
+        String content
+) {}


### PR DESCRIPTION
## ✨ 작업 내용

- 카드 업데이트 기능 구현 (`updateCard`)
  - 덱, 노트, 카드 내용 각각에 대해 선택적 업데이트 가능
  - 유효성 검사 및 존재하지 않는 엔티티에 대한 예외 처리 추가
- 카드의 학습 결과 처리 로직 분리 (`processStudyResult`)
  - `CardBehaviorFactory`를 통해 카드 상태에 따라 적절한 전략 객체를 주입
  - `StudyResult`에 따라 `fail`, `normal`, `good`, `stay` 등 학습 로직 분기
- 학습 주기 그룹 선택 로직 분리 (`processDueGroupSelection`)
  - "3day", "1week", "2week", "stay" 등의 그룹 선택을 통해 학습 간격 조절
  - 아카이브 상태에 따라 `PermanentCardBehavior`, `ThreeDayCardBehavior`로 위임 처리
- `CardUpdateRequest` DTO 생성
  - `deckId`, `noteId`, `content`를 필드로 가지며, content는 1000자 제한 유효성 검사 적용

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요? (`feature/service`)
- [x] Label을 지정했나요? (`card-update`, `behavior-pattern`, `study-processing`)

## 🎃 새롭게 알게된 사항

- 카드 상태(`isArchived`)에 따라 학습 전략을 분기 처리할 수 있어, 도메인 중심 설계와 전략 패턴이 잘 어우러짐
- `updateCard()` 메서드는 선택적 필드 수정이 가능하도록 구현되어, 프론트엔드에서 부분 변경 요청 시 유용함
- `StudyResult`와 `CardBehavior`의 조합을 통해 학습 결과에 따른 카드 변화 흐름을 명확하게 추상화할 수 있음

## 📋 참고 사항

- `CardBehavior`는 전략 패턴 기반으로 구현되어 있으며, 이후 학습 알고리즘 확장(FSRS 등)이 용이함
- 테스트 코드 미작성 상태이므로 병합 전 단위 테스트 필요 (`updateCard`, `processStudyResult`, `processDueGroupSelection`)
- 프론트엔드에서 학습 결과와 학습 그룹 선택 시 전달되는 `StudyResult`, `groupName` 값에 대한 유효성 처리도 추후 고려 필요