### PR TITLE
Feature/service-QueryDSL 설정 및 3day/permanent 카드 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,16 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.686'
 
+	// queryDSL 설정
+	implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	implementation "com.querydsl:querydsl-core"
+	implementation "com.querydsl:querydsl-collections"
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta" // querydsl JPAAnnotationProcessor 사용 지정
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 대응 코드
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api" // java.lang.NoClassDefFoundError (javax.annotation.Entity) 대응 코드
+
+
+
 
 
 	compileOnly 'org.projectlombok:lombok'
@@ -40,8 +50,31 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.assertj:assertj-core:3.24.2' // AssertJ
+	testImplementation 'org.mockito:mockito-core:5.2.0' // Mockito
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+sourceSets {
+	main.java.srcDirs += "$buildDir/generated/querydsl"
+}
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }

--- a/src/main/generated/com/Thethirdtool/backend/Card/domain/QCard.java
+++ b/src/main/generated/com/Thethirdtool/backend/Card/domain/QCard.java
@@ -1,0 +1,82 @@
+package com.Thethirdtool.backend.Card.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCard is a Querydsl query type for Card
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCard extends EntityPathBase<Card> {
+
+    private static final long serialVersionUID = 1676830057L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCard card = new QCard("card");
+
+    public final com.Thethirdtool.backend.common.jpa.QAuditingField _super = new com.Thethirdtool.backend.common.jpa.QAuditingField(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.Instant> createdAt = _super.createdAt;
+
+    public final com.Thethirdtool.backend.Deck.domain.QDeck deck;
+
+    public final DateTimePath<java.time.Instant> dueDate = createDateTime("dueDate", java.time.Instant.class);
+
+    public final EnumPath<DuePeriod> duePeriod = createEnum("duePeriod", DuePeriod.class);
+
+    public final NumberPath<Integer> easeFactor = createNumber("easeFactor", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> intervalDays = createNumber("intervalDays", Integer.class);
+
+    public final BooleanPath isArchived = createBoolean("isArchived");
+
+    public final NumberPath<Integer> lapses = createNumber("lapses", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.Instant> modifiedAt = _super.modifiedAt;
+
+    public final com.Thethirdtool.backend.Note.domain.QNote note;
+
+    public final NumberPath<Integer> reps = createNumber("reps", Integer.class);
+
+    public final NumberPath<Integer> successCount = createNumber("successCount", Integer.class);
+
+    public final ListPath<String, StringPath> tags = this.<String, StringPath>createList("tags", String.class, StringPath.class, PathInits.DIRECT2);
+
+    public QCard(String variable) {
+        this(Card.class, forVariable(variable), INITS);
+    }
+
+    public QCard(Path<? extends Card> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCard(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCard(PathMetadata metadata, PathInits inits) {
+        this(Card.class, metadata, inits);
+    }
+
+    public QCard(Class<? extends Card> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.deck = inits.isInitialized("deck") ? new com.Thethirdtool.backend.Deck.domain.QDeck(forProperty("deck"), inits.get("deck")) : null;
+        this.note = inits.isInitialized("note") ? new com.Thethirdtool.backend.Note.domain.QNote(forProperty("note")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/Thethirdtool/backend/Deck/domain/QDeck.java
+++ b/src/main/generated/com/Thethirdtool/backend/Deck/domain/QDeck.java
@@ -1,0 +1,59 @@
+package com.Thethirdtool.backend.Deck.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QDeck is a Querydsl query type for Deck
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QDeck extends EntityPathBase<Deck> {
+
+    private static final long serialVersionUID = -158807269L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QDeck deck = new QDeck("deck");
+
+    public final ListPath<com.Thethirdtool.backend.Card.domain.Card, com.Thethirdtool.backend.Card.domain.QCard> cards = this.<com.Thethirdtool.backend.Card.domain.Card, com.Thethirdtool.backend.Card.domain.QCard>createList("cards", com.Thethirdtool.backend.Card.domain.Card.class, com.Thethirdtool.backend.Card.domain.QCard.class, PathInits.DIRECT2);
+
+    public final ListPath<Deck, QDeck> children = this.<Deck, QDeck>createList("children", Deck.class, QDeck.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isFrozen = createBoolean("isFrozen");
+
+    public final StringPath name = createString("name");
+
+    public final QDeck parent;
+
+    public QDeck(String variable) {
+        this(Deck.class, forVariable(variable), INITS);
+    }
+
+    public QDeck(Path<? extends Deck> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QDeck(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QDeck(PathMetadata metadata, PathInits inits) {
+        this(Deck.class, metadata, inits);
+    }
+
+    public QDeck(Class<? extends Deck> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.parent = inits.isInitialized("parent") ? new QDeck(forProperty("parent"), inits.get("parent")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/Thethirdtool/backend/Note/domain/QNote.java
+++ b/src/main/generated/com/Thethirdtool/backend/Note/domain/QNote.java
@@ -1,0 +1,45 @@
+package com.Thethirdtool.backend.Note.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QNote is a Querydsl query type for Note
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNote extends EntityPathBase<Note> {
+
+    private static final long serialVersionUID = -1317368787L;
+
+    public static final QNote note = new QNote("note");
+
+    public final StringPath answer = createString("answer");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DateTimePath<java.time.Instant> mtime = createDateTime("mtime", java.time.Instant.class);
+
+    public final StringPath question = createString("question");
+
+    public final NumberPath<Integer> usn = createNumber("usn", Integer.class);
+
+    public QNote(String variable) {
+        super(Note.class, forVariable(variable));
+    }
+
+    public QNote(Path<? extends Note> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QNote(PathMetadata metadata) {
+        super(Note.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/Thethirdtool/backend/common/jpa/QAuditingField.java
+++ b/src/main/generated/com/Thethirdtool/backend/common/jpa/QAuditingField.java
@@ -1,0 +1,39 @@
+package com.Thethirdtool.backend.common.jpa;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QAuditingField is a Querydsl query type for AuditingField
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QAuditingField extends EntityPathBase<AuditingField> {
+
+    private static final long serialVersionUID = 458503402L;
+
+    public static final QAuditingField auditingField = new QAuditingField("auditingField");
+
+    public final DateTimePath<java.time.Instant> createdAt = createDateTime("createdAt", java.time.Instant.class);
+
+    public final DateTimePath<java.time.Instant> modifiedAt = createDateTime("modifiedAt", java.time.Instant.class);
+
+    public QAuditingField(String variable) {
+        super(AuditingField.class, forVariable(variable));
+    }
+
+    public QAuditingField(Path<? extends AuditingField> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QAuditingField(PathMetadata metadata) {
+        super(AuditingField.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/Thethirdtool/backend/Card/application/repository/CardQueryRepository.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/application/repository/CardQueryRepository.java
@@ -1,0 +1,9 @@
+package com.Thethirdtool.backend.Card.application.repository;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+
+import java.util.List;
+
+public interface CardQueryRepository {
+    List<Card> findNextCards(Long deckId, Long lastId, int size);
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/application/repository/CardQueryRepositoryImpl.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/application/repository/CardQueryRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.Thethirdtool.backend.Card.application.repository;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+import com.Thethirdtool.backend.Card.domain.QCard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CardQueryRepositoryImpl implements CardQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<Card> findNextCards(Long deckId, Long lastId, int size) {
+        QCard card = QCard.card;
+
+        return queryFactory
+                .selectFrom(card)
+                .where(
+                        card.deck.id.eq(deckId),
+                        lastId != null ? card.id.gt(lastId) : null
+                      )
+                .orderBy(card.id.asc()) // 최신순으로 하고 싶다면 desc
+                .limit(size)
+                .fetch();
+    }
+}


### PR DESCRIPTION
# ✅ Pull Request: QueryDSL 설정 및 3day/permanent 카드 조회 기능 추가

## ✨ 작업 내용

- `QueryDSL` 설정 추가 및 Q클래스 생성 위치 지정 (`build/generated` → `src/main/generated`)
- `QCard`, `QDeck`, `QNote`, `QAuditingField` 클래스 자동 생성 확인
- 카드 조회 로직 개선:
  - `getCardsFor3DayProject(Long deckId)`  
    → `archived == false` + `interval ≤ 30` 조건 카드 조회
  - `getCardsForPermanentProject(Long deckId)`  
    → `archived == true` 조건 카드 조회
- `getCardsByDuePeriod(Long deckId, String period)` 메서드 추가  
  → 3day, 1week, 2week 등의 문자열을 `DuePeriod` enum으로 변환 후 범위 필터링
- `getStudyPreview(Long cardId)` 메서드 추가  
  → 카드 상태 기반 학습 간격 사전 확인 (CardBehavior 전략 적용)

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요? (테스트 추가 예정)
- [x] Merge할 브랜치의 위치를 확인했나요? (`main` → `feature/service`)
- [x] Label을 지정했나요?

---

## 🎃 새롭게 알게된 사항

- `jakarta.annotation-api`, `jakarta.persistence-api` 의존성 누락 시 `Q` 클래스 생성 불가
- `@Generated` 어노테이션 문제는 `annotationProcessor` 설정으로 해결 가능
- `DuePeriod enum`을 통한 범위 필터링은 도메인 정책 확장에 유리함

---

## 📋 참고 사항

- 테스트 케이스는 통합 테스트 또는 서비스 단위 테스트로 추후 보완 예정
- preview 로직은 CardBehavior 전략 클래스(`ThreeDayCardBehavior`, `PermanentCardBehavior`)에 따라 preview 결과 달라짐
- 서비스 응집도 유지를 위해 `DeckService` 내부에서만 카드 필터링 기능 처리함