### PR TITLE
Feature/service-Kakao OAuth2 로그인 구현 및 Member 연동 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,13 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation platform("software.amazon.awssdk:bom:2.20.60") // BOM으로 버전 관리
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.686'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	// queryDSL 설정
 	implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -48,6 +51,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.assertj:assertj-core:3.24.2' // AssertJ

--- a/src/main/java/com/Thethirdtool/backend/Member/domain/Member.java
+++ b/src/main/java/com/Thethirdtool/backend/Member/domain/Member.java
@@ -1,0 +1,37 @@
+package com.Thethirdtool.backend.Member.domain;
+
+import com.Thethirdtool.backend.Deck.domain.Deck;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Builder
+@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String kakaoId;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String email;
+
+    // 덱 연관관계 (옵션)
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
+    private List<Deck> decks = new ArrayList<>();
+
+
+
+}

--- a/src/main/java/com/Thethirdtool/backend/Member/presentation/MemberRepository.java
+++ b/src/main/java/com/Thethirdtool/backend/Member/presentation/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.Thethirdtool.backend.Member.presentation;
+
+import com.Thethirdtool.backend.Member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByKakaoId(String kakaoId);
+}

--- a/src/main/java/com/Thethirdtool/backend/Member/presentation/MemberService.java
+++ b/src/main/java/com/Thethirdtool/backend/Member/presentation/MemberService.java
@@ -1,0 +1,24 @@
+package com.Thethirdtool.backend.Member.presentation;
+
+import com.Thethirdtool.backend.Deck.domain.Deck;
+import com.Thethirdtool.backend.Member.domain.Member;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    // 로그인한 유저 ID 기준으로 자신의 덱 목록 조회
+    @Transactional
+    public List<Deck> getMyDecks(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                                        .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+        return member.getDecks(); // 연관된 덱 리스트 반환
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/Thethirdtool/backend/security/CustomOAuth2UserService.java
@@ -1,0 +1,39 @@
+package com.Thethirdtool.backend.security;
+
+import com.Thethirdtool.backend.Member.domain.Member;
+import com.Thethirdtool.backend.Member.presentation.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public CustomUserDetails loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String kakaoId = attributes.get("id").toString();
+        String nickname = (String) profile.get("nickname");
+        //얘는 아마 없을걸?? 오류 예상
+        String email = (String) kakaoAccount.get("email");
+
+        Member member = memberRepository.findByKakaoId(kakaoId)
+                                        .orElseGet(() -> memberRepository.save(new Member(kakaoId, nickname, email)));
+
+        return new CustomUserDetails(member); // 세션에 저장됨
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/security/CustomUserDetails.java
+++ b/src/main/java/com/Thethirdtool/backend/security/CustomUserDetails.java
@@ -1,0 +1,41 @@
+package com.Thethirdtool.backend.security;
+
+import com.Thethirdtool.backend.Member.domain.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getKakaoId(); // username은 kakaoId 사용
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,21 @@ spring:
       base-path: /api
       detection-strategy: annotated
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${kakao.client-id}
+            client-secret: ${kakao.client-secret}
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
# ✅ Pull Request: Kakao OAuth2 로그인 구현 및 Member 연동 기능 추가

## ✨ 작업 내용

- ✅ Kakao OAuth2 로그인 기능 구현
  - `application.yml`에 Kakao OAuth2 관련 설정 추가 (`client-id`, `client-secret` 등)
  - Spring Security OAuth2 Client 등록 및 Provider 설정
- ✅ `CustomOAuth2UserService` 구현
  - 카카오 로그인 시 사용자 정보 파싱 (id, email, nickname)
  - 존재하지 않는 경우 `Member` 엔티티에 자동 회원가입 처리
- ✅ 도메인 및 인증 관련 클래스 추가
  - `Member` 엔티티 정의 (kakaoId, nickname, email, Deck 연관관계)
  - `MemberRepository`, `MemberService` 추가
  - `CustomUserDetails` 구현: Kakao ID 기반 `UserDetails` 설정
- ✅ 로그인 후 사용자 세션에 Member 정보 등록
  - 인증된 사용자는 `CustomUserDetails`를 통해 Member 접근 가능
- ✅ build.gradle에 AWS SDK 및 보안 설정 의존성 추가

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요? (단위 테스트 보완 예정)
- [x] Merge할 브랜치의 위치를 확인했나요? (`main` → `feature/oauth-kakao`)
- [x] Label을 지정했나요? (`kakao-login`, `auth`, `feature` 등)

---

## 🎃 새롭게 알게된 사항

- `OAuth2UserService` 커스터마이징 시, Kakao는 내부 JSON이 nested 구조 (`kakao_account.profile`)로 되어 있어 파싱에 주의 필요
- `@RequiredArgsConstructor` + `NoArgsConstructor(access = PROTECTED)` 조합으로 엔티티 생성 + JPA 프록시 충돌 방지 가능
- 로그인 후 사용자 정보를 Spring Security 세션에 올리려면 `CustomUserDetails`가 필수

---

## 📋 참고 사항

- 로그인 이후 사용자 전용 기능(덱 관리 등)을 위한 추가 API 구성 예정
- 회원가입 시 필수 항목이 Kakao에서 모두 제공되지 않을 수 있음 → 사용자에게 nickname 수정 요청 UI 필요성 고려
- OAuth2 설정은 추후 Google/Apple 등 확장을 고려해 `ClientRegistrationRepository` 분리 예정