### PR TITLE
Feature/application-카드/덱 API 및 인증/검증 로직 구현

### DIFF
--- a/src/main/java/com/Thethirdtool/backend/Card/dto/response/ApiResponse.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/dto/response/ApiResponse.java
@@ -1,0 +1,11 @@
+package com.Thethirdtool.backend.Card.dto.response;
+
+public record ApiResponse<T>(boolean success, T data, String message) {
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(false, null, message);
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/dto/response/CardResponse.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/dto/response/CardResponse.java
@@ -1,0 +1,31 @@
+package com.Thethirdtool.backend.Card.dto.response;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+
+public record CardResponse(
+        Long cardId,
+        String question,
+        String answer,
+        int intervalDays,
+        boolean isArchived,
+        int successCount,
+        int reps,
+        int easeFactor,
+        int lapses,
+        String imageUrl // ✅ 추가된 필드
+) {
+    public static CardResponse from(Card card) {
+        return new CardResponse(
+                card.getId(),
+                card.getNote().getQuestion(),
+                card.getNote().getAnswer(),
+                card.getIntervalDays(),
+                card.isArchived(),
+                card.getSuccessCount(),
+                card.getReps(),
+                card.getEaseFactor(),
+                card.getLapses(),
+                card.getImageUrl() // ✅ 추가된 값
+        );
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/presentation/CardController.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/presentation/CardController.java
@@ -1,0 +1,4 @@
+package com.Thethirdtool.backend.Card.presentation;
+
+public class CardController {
+}

--- a/src/main/java/com/Thethirdtool/backend/Deck/dto/request/DeckCreateRequest.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/dto/request/DeckCreateRequest.java
@@ -1,0 +1,11 @@
+package com.Thethirdtool.backend.Deck.dto.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DeckCreateRequest(
+        @NotBlank(message = "덱 이름은 필수입니다.")
+        String name,
+
+        Long parentId // 루트 덱이면 null
+) {}

--- a/src/main/java/com/Thethirdtool/backend/Deck/dto/response/DeckResponse.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/dto/response/DeckResponse.java
@@ -1,0 +1,4 @@
+package com.Thethirdtool.backend.Deck.dto.response;
+
+public class DeckResponse {
+}

--- a/src/main/java/com/Thethirdtool/backend/Deck/dto/response/DeckResponse.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/dto/response/DeckResponse.java
@@ -1,4 +1,26 @@
 package com.Thethirdtool.backend.Deck.dto.response;
 
+import com.Thethirdtool.backend.Deck.domain.Deck;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class DeckResponse {
+
+    private Long id;
+    private String name;
+    private boolean isFrozen;
+    private boolean isRoot;
+    private boolean hasChildren;
+
+    public static DeckResponse from(Deck deck) {
+        return DeckResponse.builder()
+                           .id(deck.getId())
+                           .name(deck.getName())
+                           .isFrozen(deck.isFrozen())
+                           .isRoot(deck.isRoot())
+                           .hasChildren(deck.getChildren() != null && !deck.getChildren().isEmpty())
+                           .build();
+    }
 }

--- a/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
@@ -3,22 +3,28 @@ package com.Thethirdtool.backend.Deck.presentation;
 
 import com.Thethirdtool.backend.Card.application.CardService;
 import com.Thethirdtool.backend.Card.domain.Card;
+import com.Thethirdtool.backend.Card.dto.request.CardCreateRequest;
 import com.Thethirdtool.backend.Card.dto.response.ApiResponse;
 import com.Thethirdtool.backend.Card.dto.response.CardResponse;
 import com.Thethirdtool.backend.Deck.application.DeckService;
 import com.Thethirdtool.backend.Deck.domain.Deck;
+import com.Thethirdtool.backend.Deck.dto.request.DeckCreateRequest;
 import com.Thethirdtool.backend.Deck.dto.response.DeckResponse;
 import com.Thethirdtool.backend.Image.application.ImageService;
 import com.Thethirdtool.backend.common.validation.AuthValidationDto;
 import com.Thethirdtool.backend.security.CustomUserDetails;
 import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Valid;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.nio.file.AccessDeniedException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -90,6 +96,49 @@ public class DeckController {
         validateUser(userId, userDetails);
         List<Card> cards = deckService.getArchivedCardsFromDeckTree(deckId);
         return ResponseEntity.ok(ApiResponse.ok(cards.stream().map(CardResponse::from).toList()));
+    }
+
+    @GetMapping("/{deckId}/cards/due")
+    public ResponseEntity<ApiResponse<List<CardResponse>>> getDueCardsByPeriod(
+            @PathVariable Long userId,
+            @PathVariable Long deckId,
+            @RequestParam String period,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        List<Card> cards = cardService.getCardsByDuePeriod(deckId, period);
+        return ResponseEntity.ok(ApiResponse.ok(cards.stream().map(CardResponse::from).toList()));
+    }
+
+    @PostMapping("/{parentId}/children")
+    public ResponseEntity<ApiResponse<DeckResponse>> createChildDeck(
+            @PathVariable Long userId,
+            @PathVariable Long parentId,
+            @RequestBody @Valid DeckCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        Deck child = deckService.createChildDeck(parentId, request.name());
+        return ResponseEntity.ok(ApiResponse.ok(DeckResponse.from(child)));
+    }
+
+    @PostMapping(value = "/{deckId}/cards", consumes = "multipart/form-data")
+    public ResponseEntity<ApiResponse<CardResponse>> createCard(
+            @PathVariable Long userId,
+            @PathVariable Long deckId,
+            @RequestPart("data") @Valid CardCreateRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws IOException, AccessDeniedException {
+        validateUser(userId, userDetails);
+
+        List<String> imageUrls = new ArrayList<>();
+        if (images != null) {
+            for (MultipartFile image : images) {
+                String url = imageService.imageUpload(image);
+                imageUrls.add(url);
+            }
+        }
+
+        Card card = cardService.createCard(deckId, request.noteId(), request, imageUrls);
+        return ResponseEntity.ok(ApiResponse.ok(CardResponse.from(card)));
     }
 
 

--- a/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
@@ -7,7 +7,9 @@ import com.Thethirdtool.backend.Deck.application.DeckService;
 import com.Thethirdtool.backend.Deck.domain.Deck;
 import com.Thethirdtool.backend.Deck.dto.response.DeckResponse;
 import com.Thethirdtool.backend.Image.application.ImageService;
+import com.Thethirdtool.backend.common.validation.AuthValidationDto;
 import com.Thethirdtool.backend.security.CustomUserDetails;
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor
@@ -65,6 +68,17 @@ public class DeckController {
         validateUser(userId, userDetails);
         deckService.unfreezeDeck(deckId);
         return ResponseEntity.ok(ApiResponse.ok("성공적으로 녹였습니다."));
+    }
+
+
+
+    // ✅ 공통 인증 검증
+    private void validateUser(Long userId, CustomUserDetails userDetails) throws AccessDeniedException {
+        AuthValidationDto dto = new AuthValidationDto(userId, userDetails.getMember().getId());
+        Set<ConstraintViolation<AuthValidationDto>> violations = validator.validate(dto);
+        if (!violations.isEmpty()) {
+            throw new AccessDeniedException(violations.iterator().next().getMessage());
+        }
     }
 
 

--- a/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
@@ -2,6 +2,7 @@ package com.Thethirdtool.backend.Deck.presentation;
 
 
 import com.Thethirdtool.backend.Card.application.CardService;
+import com.Thethirdtool.backend.Card.dto.response.ApiResponse;
 import com.Thethirdtool.backend.Deck.application.DeckService;
 import com.Thethirdtool.backend.Deck.domain.Deck;
 import com.Thethirdtool.backend.Deck.dto.response.DeckResponse;
@@ -11,10 +12,7 @@ import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;
@@ -37,5 +35,38 @@ public class DeckController {
         List<Deck> decks = deckService.getRootDecks();
         return ResponseEntity.ok(ApiResponse.ok(decks.stream().map(DeckResponse::from).toList()));
     }
+
+    //자식 덱 가져오기
+    @GetMapping("/{deckId}/children")
+    public ResponseEntity<ApiResponse<List<DeckResponse>>> getChildren(
+            @PathVariable Long userId,
+            @PathVariable Long deckId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        List<Deck> children = deckService.getImmediateChildren(deckId);
+        return ResponseEntity.ok(ApiResponse.ok(children.stream().map(DeckResponse::from).toList()));
+    }
+
+    @PatchMapping("/{deckId}/freeze")
+    public ResponseEntity<ApiResponse<String>> freezeDeck(
+            @PathVariable Long userId,
+            @PathVariable Long deckId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        deckService.freezeDeck(deckId);
+        return ResponseEntity.ok(ApiResponse.ok("성공적으로 얼렸습니다."));
+    }
+
+    @PatchMapping("/{deckId}/unfreeze")
+    public ResponseEntity<ApiResponse<String>> unfreezeDeck(
+            @PathVariable Long userId,
+            @PathVariable Long deckId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        deckService.unfreezeDeck(deckId);
+        return ResponseEntity.ok(ApiResponse.ok("성공적으로 녹였습니다."));
+    }
+
+
 
 }

--- a/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
@@ -1,0 +1,12 @@
+package com.Thethirdtool.backend.Deck.presentation;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members/{userId}/decks")
+public class DeckController {
+}

--- a/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
@@ -2,7 +2,9 @@ package com.Thethirdtool.backend.Deck.presentation;
 
 
 import com.Thethirdtool.backend.Card.application.CardService;
+import com.Thethirdtool.backend.Card.domain.Card;
 import com.Thethirdtool.backend.Card.dto.response.ApiResponse;
+import com.Thethirdtool.backend.Card.dto.response.CardResponse;
 import com.Thethirdtool.backend.Deck.application.DeckService;
 import com.Thethirdtool.backend.Deck.domain.Deck;
 import com.Thethirdtool.backend.Deck.dto.response.DeckResponse;
@@ -68,6 +70,26 @@ public class DeckController {
         validateUser(userId, userDetails);
         deckService.unfreezeDeck(deckId);
         return ResponseEntity.ok(ApiResponse.ok("성공적으로 녹였습니다."));
+    }
+
+    @GetMapping("/{deckId}/cards/3day")
+    public ResponseEntity<ApiResponse<List<CardResponse>>> getCardsFor3Day(
+            @PathVariable Long userId,
+            @PathVariable Long deckId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        List<Card> cards = deckService.getCardsFor3DayProject(deckId);
+        return ResponseEntity.ok(ApiResponse.ok(cards.stream().map(CardResponse::from).toList()));
+    }
+
+    @GetMapping("/{deckId}/cards/permanent")
+    public ResponseEntity<ApiResponse<List<CardResponse>>> getCardsForPermanent(
+            @PathVariable Long userId,
+            @PathVariable Long deckId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        List<Card> cards = deckService.getArchivedCardsFromDeckTree(deckId);
+        return ResponseEntity.ok(ApiResponse.ok(cards.stream().map(CardResponse::from).toList()));
     }
 
 

--- a/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/presentation/DeckController.java
@@ -1,12 +1,41 @@
 package com.Thethirdtool.backend.Deck.presentation;
 
 
+import com.Thethirdtool.backend.Card.application.CardService;
+import com.Thethirdtool.backend.Deck.application.DeckService;
+import com.Thethirdtool.backend.Deck.domain.Deck;
+import com.Thethirdtool.backend.Deck.dto.response.DeckResponse;
+import com.Thethirdtool.backend.Image.application.ImageService;
+import com.Thethirdtool.backend.security.CustomUserDetails;
+import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members/{userId}/decks")
 public class DeckController {
+
+    private final DeckService deckService;
+    private final CardService cardService;
+    private final ImageService imageService;
+    private final Validator validator;
+
+    @GetMapping("/roots")
+    public ResponseEntity<ApiResponse<List<DeckResponse>>> getRootDecks(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        List<Deck> decks = deckService.getRootDecks();
+        return ResponseEntity.ok(ApiResponse.ok(decks.stream().map(DeckResponse::from).toList()));
+    }
+
 }

--- a/src/main/java/com/Thethirdtool/backend/common/annotation/AuthenticatedUserMatch.java
+++ b/src/main/java/com/Thethirdtool/backend/common/annotation/AuthenticatedUserMatch.java
@@ -1,0 +1,16 @@
+package com.Thethirdtool.backend.common.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = AuthenticatedUserMatchValidator.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticatedUserMatch {
+    String message() default "접근 권한이 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/Thethirdtool/backend/common/config/QuerydslConfig.java
+++ b/src/main/java/com/Thethirdtool/backend/common/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.Thethirdtool.backend.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/Thethirdtool/backend/common/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package com.Thethirdtool.backend.common.config;
+
+import com.Thethirdtool.backend.security.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .authorizeHttpRequests(auth -> auth
+                                .requestMatchers("/", "/login/**", "/oauth2/**").permitAll()
+                                .anyRequest().authenticated()
+                                      )
+                .oauth2Login(oauth2 -> oauth2
+                                .userInfoEndpoint(userInfo -> userInfo
+                                                .userService(customOAuth2UserService)
+                                                 )
+                            );
+
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/common/validation/AuthValidationDto.java
+++ b/src/main/java/com/Thethirdtool/backend/common/validation/AuthValidationDto.java
@@ -1,0 +1,22 @@
+package com.Thethirdtool.backend.common.validation;
+
+import com.Thethirdtool.backend.common.annotation.AuthenticatedUserMatch;
+
+@AuthenticatedUserMatch
+public class AuthValidationDto {
+    private final Long pathUserId;
+    private final Long authenticatedUserId;
+
+    public AuthValidationDto(Long pathUserId, Long authenticatedUserId) {
+        this.pathUserId = pathUserId;
+        this.authenticatedUserId = authenticatedUserId;
+    }
+
+    public Long getPathUserId() {
+        return pathUserId;
+    }
+
+    public Long getAuthenticatedUserId() {
+        return authenticatedUserId;
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/common/validation/AuthenticatedUserMatchValidator.java
+++ b/src/main/java/com/Thethirdtool/backend/common/validation/AuthenticatedUserMatchValidator.java
@@ -1,0 +1,14 @@
+package com.Thethirdtool.backend.common.validation;
+
+
+import com.Thethirdtool.backend.common.annotation.AuthenticatedUserMatch;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class AuthenticatedUserMatchValidator implements ConstraintValidator<AuthenticatedUserMatch, AuthValidationDto> {
+    @Override
+    public boolean isValid(AuthValidationDto dto, ConstraintValidatorContext context) {
+        if (dto == null) return false;
+        return dto.getPathUserId().equals(dto.getAuthenticatedUserId());
+    }
+}


### PR DESCRIPTION
# ✅ Pull Request: 카드/덱 API 및 인증/검증 로직 구현

## ✨ 작업 내용

### 1. 공통 응답 포맷 정의
- `ApiResponse<T>`: 성공/에러 응답을 공통 형식으로 통일
- `CardResponse`, `DeckResponse`: 각 도메인별 응답 DTO 구성

### 2. 카드 관련 기능 추가
- 이미지 URL 포함된 카드 응답 DTO `CardResponse` 작성
- `CardController` 파일 생성 (구현은 미완)

### 3. 덱 관련 기능 및 컨트롤러 구현
- `DeckController`:
  - 루트/자식 덱 조회
  - 덱 동결/해제 (freeze/unfreeze)
  - 카드 필터링 조회 (3day, permanent, 기간 필터링)
  - 카드 생성 + 이미지 업로드 통합 (multipart 처리)
- `DeckCreateRequest`, `DeckResponse` DTO 추가

### 4. 인증/인가 처리
- `@AuthenticatedUserMatch`: 사용자 본인 검증을 위한 커스텀 어노테이션
- `AuthValidationDto` + `AuthenticatedUserMatchValidator`: `PathVariable userId`와 로그인 유저 일치 여부 검증
- 모든 요청 시 `validateUser(userId, userDetails)` 방식으로 일관되게 처리

### 5. 공통 Config 추가
- `QuerydslConfig`: JPAQueryFactory 빈 등록
- `SecurityConfig`: Spring Security + Kakao OAuth2 로그인 설정

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요? (예외 처리 및 카드 이미지 테스트 추가 예정)
- [x] Merge할 브랜치의 위치를 확인했나요? (`feature/application`)
- [x] Label을 지정했나요? (`feature`, `deck`, `card`, `auth`, `security` 등)

---

## 🎃 새롭게 알게된 사항

- `@Validated`와 `@AuthenticationPrincipal` 조합 시 커스텀 DTO 검증을 활용하면 세션 기반 인증 검증을 코드에서 명확히 분리할 수 있음
- `multipart/form-data`로 카드 생성 시 이미지까지 처리하는 것이 사용자 UX 측면에서 매우 효율적임
- QueryDSL을 적용하면서 코드의 가독성과 유연성이 향상됨

---

## 📋 참고 사항

- `CardController`는 현재 빈 상태이며, 카드 개별 조회/수정/삭제 기능은 추후 브랜치에서 분리하여 구현 예정
- DeckService 내부의 카드 관련 로직은 CardService로 분리 가능성 있음
- 인증 검증 로직이 반복되므로 AOP 혹은 공통 모듈로 리팩토링 고려 가능