### PR TITLE
[feature/application] 카드 컨트롤러 crud 관련 작업을 진행하였습니다!

### DIFF
--- a/src/main/java/com/Thethirdtool/backend/Card/dto/CardStudyViewDto.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/dto/CardStudyViewDto.java
@@ -1,0 +1,29 @@
+package com.Thethirdtool.backend.Card.dto;
+
+import com.Thethirdtool.backend.Card.domain.Card;
+
+public record CardStudyViewDto(
+        Long cardId,
+        String question,
+        String answer,
+        int intervalDays,
+        boolean isArchived,
+        int successCount,
+        int reps,
+        int easeFactor,
+        int lapses
+) {
+    public static CardStudyViewDto from(Card card) {
+        return new CardStudyViewDto(
+                card.getId(),
+                card.getNote().getQuestion(),
+                card.getNote().getAnswer(),
+                card.getIntervalDays(),
+                card.isArchived(),
+                card.getSuccessCount(),
+                card.getReps(),
+                card.getEaseFactor(),
+                card.getLapses()
+        );
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/presentation/CardController.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/presentation/CardController.java
@@ -1,4 +1,72 @@
 package com.Thethirdtool.backend.Card.presentation;
 
+import com.Thethirdtool.backend.Card.application.CardService;
+import com.Thethirdtool.backend.Card.dto.request.CardUpdateRequest;
+import com.Thethirdtool.backend.Card.dto.response.ApiResponse;
+import com.Thethirdtool.backend.Card.dto.response.CardResponse;
+import com.Thethirdtool.backend.common.validation.AuthValidationDto;
+import com.Thethirdtool.backend.security.CustomUserDetails;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Valid;
+import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.file.AccessDeniedException;
+import java.util.Set;
+
+
+@RestController
+@RequestMapping("/members/{userId}/cards")
+@RequiredArgsConstructor
 public class CardController {
+
+    private final CardService cardService;
+    private final Validator validator;
+
+    // 카드 수정
+    @PatchMapping("/{cardId}")
+    public ResponseEntity<ApiResponse<CardResponse>> updateCard(
+            @PathVariable Long userId,
+            @PathVariable Long cardId,
+            @Valid @RequestBody CardUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        return ResponseEntity.ok(ApiResponse.ok(CardResponse.from(cardService.updateCard(cardId, request))));
+    }
+
+    // 카드 삭제
+    @DeleteMapping("/{cardId}")
+    public ResponseEntity<ApiResponse<String>> deleteCard(
+            @PathVariable Long userId,
+            @PathVariable Long cardId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        cardService.deleteCard(cardId);
+        return ResponseEntity.ok(ApiResponse.ok("성공적으로 삭제하였습니다."));
+    }
+
+
+    // 카드 학습 진입 (단일 선택 시)
+    @GetMapping("/{cardId}/study")
+    public ResponseEntity<ApiResponse<CardStudyViewDto>> getStudyCard(
+            @PathVariable Long userId,
+            @PathVariable Long cardId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        return ResponseEntity.ok(ApiResponse.ok(cardService.getCardStudyView(cardId)));
+    }
+
+
+    // ✅ 공통 검증 메서드 ->>> 공통메서드 뽑을 줄 알기
+    private void validateUser(Long userId, CustomUserDetails userDetails) throws AccessDeniedException {
+        AuthValidationDto dto = new AuthValidationDto(userId, userDetails.getMember().getId());
+        Set<ConstraintViolation<AuthValidationDto>> violations = validator.validate(dto);
+        if (!violations.isEmpty()) {
+            throw new AccessDeniedException(violations.iterator().next().getMessage());
+        }
+    }
+
 }


### PR DESCRIPTION
# ✅ Pull Request: 카드 CRUD 기능 구현 (Update, Delete, Study 진입)

## ✨ 작업 내용

### 1. 카드 수정 기능 추가
- `PATCH /members/{userId}/cards/{cardId}`
- `CardUpdateRequest` 를 이용해 카드의 덱, 노트, 내용 변경 가능
- `CardService.updateCard()` 호출 후 결과를 `CardResponse`로 응답

### 2. 카드 삭제 기능 추가
- `DELETE /members/{userId}/cards/{cardId}`
- 카드 삭제 처리 후 단순 성공 메시지 반환

### 3. 카드 학습 진입 기능 추가
- `GET /members/{userId}/cards/{cardId}/study`
- 단일 카드 학습 진입 시 필요한 데이터를 `CardStudyViewDto` 로 응답
- question, answer, intervalDays, successCount 등 학습에 필요한 정보 포함

### 4. 공통 사용자 인증 검증 적용
- 모든 요청에 대해 `validateUser(userId, userDetails)` 공통 메서드 사용
- 세션 사용자 ID와 PathVariable userId 일치 여부 검증

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요? (→ 추후 Controller 테스트 추가 예정)
- [x] merge할 브랜치의 위치를 확인했나요? (`feature/application`)
- [x] Label을 지정했나요? (`feature`, `card`, `crud`)

---

## 🎃 새롭게 알게된 사항

- `@AuthenticationPrincipal`을 이용해 로그인된 사용자 인증 정보를 직접 받아 사용할 수 있으며,
- 커스텀 검증 어노테이션 없이 Validator를 활용해 동적으로 인증 로직을 처리하는 방식이 간편하고 직관적임

---

## 📋 참고 사항

- 현재는 단일 카드 단위의 CRUD만 구현된 상태이며, 이후 목록 조회, 복습 기록 저장 기능은 별도 브랜치에서 작업 예정
- 카드 학습 응답에서 이미지 URL 등 시각적 요소가 필요한 경우에는 `CardStudyViewDto` 확장 고려