### PR TITLE
Feature/application-카드 학습 기능 추가 (Preview & 결과 전송)

### DIFF
--- a/src/main/java/com/Thethirdtool/backend/Card/application/CardService.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/application/CardService.java
@@ -7,6 +7,7 @@ import com.Thethirdtool.backend.Card.domain.DuePeriod;
 import com.Thethirdtool.backend.Card.domain.StudyPolicy.CardBehavior;
 import com.Thethirdtool.backend.Card.domain.StudyPolicy.CardBehaviorFactory;
 import com.Thethirdtool.backend.Card.domain.StudyResult;
+import com.Thethirdtool.backend.Card.dto.CardStudyViewDto;
 import com.Thethirdtool.backend.Card.dto.request.CardCreateRequest;
 import com.Thethirdtool.backend.Card.dto.request.CardUpdateRequest;
 import com.Thethirdtool.backend.Deck.application.repository.DeckRepository;
@@ -32,6 +33,14 @@ public class CardService {
     private final DeckRepository deckRepository;
     private final NoteRepository noteRepository;
 
+
+    //카드 단건 조회- 스크롤링 방식- 근데 할 일이 없을거 같음
+    @Transactional(readOnly = true)
+    public CardStudyViewDto getCardStudyView(Long cardId) {
+        Card card = cardRepository.findById(cardId)
+                                  .orElseThrow(() -> new EntityNotFoundException("카드를 찾을 수 없습니다."));
+        return CardStudyViewDto.from(card);
+    }
 
 
     // ✅ 카드 생성

--- a/src/main/java/com/Thethirdtool/backend/Card/application/repository/querydsl/CardQueryRepository.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/application/repository/querydsl/CardQueryRepository.java
@@ -1,4 +1,4 @@
-package com.Thethirdtool.backend.Card.application.repository;
+package com.Thethirdtool.backend.Card.application.repository.querydsl;
 
 import com.Thethirdtool.backend.Card.domain.Card;
 

--- a/src/main/java/com/Thethirdtool/backend/Card/application/repository/querydsl/CardQueryRepositoryImpl.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/application/repository/querydsl/CardQueryRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.Thethirdtool.backend.Card.application.repository;
+package com.Thethirdtool.backend.Card.application.repository.querydsl;
 
 import com.Thethirdtool.backend.Card.domain.Card;
 import com.Thethirdtool.backend.Card.domain.QCard;

--- a/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardStudyResultRequest.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardStudyResultRequest.java
@@ -1,4 +1,9 @@
 package com.Thethirdtool.backend.Card.dto.request;
 
-public record CardStudyResultRequest() {
-}
+import com.Thethirdtool.backend.Card.domain.StudyResult;
+import jakarta.validation.constraints.NotNull;
+
+public record CardStudyResultRequest(
+        @NotNull(message = "학습 결과는 필수입니다.")
+        StudyResult result
+) {}

--- a/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardStudyResultRequest.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardStudyResultRequest.java
@@ -1,0 +1,4 @@
+package com.Thethirdtool.backend.Card.dto.request;
+
+public record CardStudyResultRequest() {
+}

--- a/src/main/java/com/Thethirdtool/backend/Card/presentation/CardController.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/presentation/CardController.java
@@ -1,6 +1,8 @@
 package com.Thethirdtool.backend.Card.presentation;
 
 import com.Thethirdtool.backend.Card.application.CardService;
+import com.Thethirdtool.backend.Card.dto.CardStudyViewDto;
+import com.Thethirdtool.backend.Card.dto.request.CardStudyResultRequest;
 import com.Thethirdtool.backend.Card.dto.request.CardUpdateRequest;
 import com.Thethirdtool.backend.Card.dto.response.ApiResponse;
 import com.Thethirdtool.backend.Card.dto.response.CardResponse;
@@ -15,6 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
+import java.util.Map;
 import java.util.Set;
 
 
@@ -58,6 +61,29 @@ public class CardController {
         validateUser(userId, userDetails);
         return ResponseEntity.ok(ApiResponse.ok(cardService.getCardStudyView(cardId)));
     }
+
+    // 학습 전 프리뷰
+    @GetMapping("/{cardId}/study/preview")
+    public ResponseEntity<ApiResponse<Map<String, String>>> getStudyPreview(
+            @PathVariable Long userId,
+            @PathVariable Long cardId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        return ResponseEntity.ok(ApiResponse.ok(cardService.getStudyPreview(cardId)));
+    }
+
+    // 학습 결과 전송
+    @PostMapping("/{cardId}/study/result")
+    public ResponseEntity<ApiResponse<String>> studyResult(
+            @PathVariable Long userId,
+            @PathVariable Long cardId,
+            @Valid @RequestBody CardStudyResultRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        validateUser(userId, userDetails);
+        cardService.processStudyResult(cardId, request.result());
+        return ResponseEntity.ok(ApiResponse.ok("보내는데 성공하였습니다."));
+    }
+
 
 
     // ✅ 공통 검증 메서드 ->>> 공통메서드 뽑을 줄 알기


### PR DESCRIPTION
# ✅ Pull Request: 카드 학습 기능 추가 (Preview & 결과 전송)

## ✨ 작업 내용

### 1. 카드 학습 전용 프리뷰 API 추가
- `GET /members/{userId}/cards/{cardId}/study/preview`
- 카드의 학습 결과별 예상 학습 간격 정보를 Map<String, String> 형태로 반환
- `CardBehavior.previewIntervals()` 로직 활용

### 2. 카드 학습 결과 전송 API 추가
- `POST /members/{userId}/cards/{cardId}/study/result`
- `CardStudyResultRequest` 를 통해 `StudyResult` 값을 전송받아 처리
- 내부적으로 `CardBehaviorFactory`를 통해 `CardBehavior` 로직 위임 처리
- 성공 시 `"보내는데 성공하였습니다."` 메시지 응답

### 3. CardService에 학습 로직 관련 메서드 추가
- `getStudyPreview(Long cardId)`
- `processStudyResult(Long cardId, StudyResult result)`
- 도메인 규칙에 따라 카드 상태 변경 처리

### 4. 디렉토리 구조 개선
- QueryDSL 관련 Repository 클래스를 `repository.querydsl` 디렉토리로 이동

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요? (→ 추후 단위 테스트 추가 예정)
- [x] merge할 브랜치의 위치를 확인했나요? (`feature/application`)
- [x] Label을 지정했나요? (`feature`, `card`, `study`, `querydsl`)

---

## 🎃 새롭게 알게된 사항

- QueryDSL QueryRepository를 분리된 디렉토리로 구성하면 유지보수가 쉬움
- 학습 로직은 전략 패턴 기반의 `CardBehavior` 구조를 통해 깔끔하게 분기 처리 가능

---

## 📋 참고 사항

- `CardStudyResultRequest`에 Enum Validation이 추가되었으므로 클라이언트에서는 정확한 ENUM 값 사용이 필요
- Card 단일 학습 흐름은 완성되었고, 이후 복수 학습이나 학습 결과 통계는 별도 이슈에서 다룰 예정입니다