### PR TITLE
Feature/application

### DIFF
--- a/src/main/generated/com/Thethirdtool/backend/Member/domain/QMember.java
+++ b/src/main/generated/com/Thethirdtool/backend/Member/domain/QMember.java
@@ -1,0 +1,46 @@
+package com.Thethirdtool.backend.Member.domain;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QMember is a Querydsl query type for Member
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QMember extends EntityPathBase<Member> {
+
+    private static final long serialVersionUID = 1285591421L;
+
+    public static final QMember member = new QMember("member1");
+
+    public final ListPath<com.Thethirdtool.backend.Deck.domain.Deck, com.Thethirdtool.backend.Deck.domain.QDeck> decks = this.<com.Thethirdtool.backend.Deck.domain.Deck, com.Thethirdtool.backend.Deck.domain.QDeck>createList("decks", com.Thethirdtool.backend.Deck.domain.Deck.class, com.Thethirdtool.backend.Deck.domain.QDeck.class, PathInits.DIRECT2);
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath kakaoId = createString("kakaoId");
+
+    public final StringPath nickname = createString("nickname");
+
+    public QMember(String variable) {
+        super(Member.class, forVariable(variable));
+    }
+
+    public QMember(Path<? extends Member> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QMember(PathMetadata metadata) {
+        super(Member.class, metadata);
+    }
+
+}
+

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
@@ -50,6 +50,7 @@ public class Card extends AuditingField {
     private DuePeriod duePeriod;
 
     //카드 썸네일 관련 태그
+    @Builder.Default
     @ElementCollection
     @CollectionTable(name = "card_tags", joinColumns = @JoinColumn(name = "card_id"))
     @Column(name = "tag")

--- a/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/domain/Card.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@RequiredArgsConstructor
 @Builder
 @Entity
 public class Card extends AuditingField {

--- a/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardCreateRequest.java
+++ b/src/main/java/com/Thethirdtool/backend/Card/dto/request/CardCreateRequest.java
@@ -1,4 +1,54 @@
 package com.Thethirdtool.backend.Card.dto.request;
 
-public record CardCreateRequest() {
+import com.Thethirdtool.backend.Card.domain.Card;
+import com.Thethirdtool.backend.Deck.domain.Deck;
+import com.Thethirdtool.backend.Note.domain.Note;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CardCreateRequest(
+        @NotNull(message = "노트 ID는 필수입니다.")
+        Long noteId,
+
+        @NotBlank(message = "카드 내용은 비워둘 수 없습니다.")
+        String content,
+
+        @Size(max = 10, message = "태그는 최대 10개까지 등록할 수 있습니다.")
+        List<@NotBlank(message = "태그는 비워둘 수 없습니다.") String> tags,
+
+        // ✅ 이미지 파일 리스트 추가
+        @Size(max = 3, message = "이미지는 최대 3개까지 등록할 수 있습니다.")
+        List<MultipartFile> images
+) {
+
+    public static CardCreateRequest of(Long noteId, String content, List<String> tags, List<MultipartFile> images) {
+        return new CardCreateRequest(noteId, content, tags, images);
+    }
+
+    // Entity 변환 시에는 이미지 URL은 따로 설정
+    public Card toEntity(Deck deck, Note note, List<String> imageUrls) {
+        if (imageUrls != null && imageUrls.size() > 3) {
+            throw new IllegalArgumentException("이미지는 최대 3개까지 등록할 수 있습니다.");
+        }
+        Card card= Card.builder()
+                       .deck(deck)
+                       .note(note)
+                       .content(this.content)
+                       .tags(this.tags)
+                       .dueDate(Instant.now().plusSeconds(86400L)) // 기본 1일 후
+                       .intervalDays(1)
+                       .easeFactor(2500)
+                       .successCount(0)
+                       .reps(0)
+                       .lapses(0)
+                       .build();
+
+        card.setImageUrls(imageUrls);
+        return card;
+    }
 }

--- a/src/main/java/com/Thethirdtool/backend/Deck/application/DeckService.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/application/DeckService.java
@@ -14,9 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
-@AllArgsConstructor // Builder를 위해 필요
+@RequiredArgsConstructor // Builder를 위해 필요
 @Transactional
-@RequiredArgsConstructor
 @Service
 public class DeckService {
     private final DeckRepository deckRepository;

--- a/src/main/java/com/Thethirdtool/backend/Deck/domain/Deck.java
+++ b/src/main/java/com/Thethirdtool/backend/Deck/domain/Deck.java
@@ -12,16 +12,17 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Deck {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Builder.Default
     @OneToMany(mappedBy = "deck", fetch = FetchType.LAZY)
     private List<Card> cards = new ArrayList<>();
 
+    @Builder.Default
     @Column(nullable = false)
     private boolean isFrozen = false;
 
@@ -31,6 +32,7 @@ public class Deck {
     @JoinColumn(name = "parent_id")
     private Deck parent;
 
+    @Builder.Default
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
     private List<Deck> children = new ArrayList<>();
 

--- a/src/main/java/com/Thethirdtool/backend/Member/application/MemberController.java
+++ b/src/main/java/com/Thethirdtool/backend/Member/application/MemberController.java
@@ -1,0 +1,21 @@
+package com.Thethirdtool.backend.Member.application;
+
+import com.Thethirdtool.backend.Card.dto.response.ApiResponse;
+import com.Thethirdtool.backend.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<Long>> getMyId(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(ApiResponse.ok(userDetails.getMember().getId()));
+    }
+}

--- a/src/main/java/com/Thethirdtool/backend/Member/domain/Member.java
+++ b/src/main/java/com/Thethirdtool/backend/Member/domain/Member.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 
 @Builder
-@RequiredArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity

--- a/src/main/java/com/Thethirdtool/backend/Member/domain/Member.java
+++ b/src/main/java/com/Thethirdtool/backend/Member/domain/Member.java
@@ -28,6 +28,7 @@ public class Member {
     private String email;
 
     // 덱 연관관계 (옵션)
+    @Builder.Default
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
     private List<Deck> decks = new ArrayList<>();
 

--- a/src/main/java/com/Thethirdtool/backend/common/annotation/AuthenticatedUserMatch.java
+++ b/src/main/java/com/Thethirdtool/backend/common/annotation/AuthenticatedUserMatch.java
@@ -1,5 +1,6 @@
 package com.Thethirdtool.backend.common.annotation;
 
+import com.Thethirdtool.backend.common.validation.AuthenticatedUserMatchValidator;
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 

--- a/src/main/java/com/Thethirdtool/backend/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/Thethirdtool/backend/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.Thethirdtool.backend.common.error;
+
+import com.Thethirdtool.backend.Card.dto.response.ApiResponse;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // DTO 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<?> handleValidationError(MethodArgumentNotValidException ex) {
+        String errorMessage = ex.getBindingResult().getFieldErrors()
+                                .stream()
+                                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                                .findFirst()
+                                .orElse("유효성 검사에 실패했습니다.");
+
+        return ApiResponse.error(errorMessage);
+    }
+
+    // 단일 필드 제약조건 위반 (예: @RequestParam 등)
+    @ExceptionHandler(ConstraintViolationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<?> handleConstraintViolation(ConstraintViolationException ex) {
+        return ApiResponse.error("잘못된 요청: " + ex.getMessage());
+    }
+
+    // 엔티티를 찾지 못했을 경우
+    @ExceptionHandler(EntityNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ApiResponse<?> handleEntityNotFound(EntityNotFoundException ex) {
+        return ApiResponse.error(ex.getMessage());
+    }
+
+    // 기타 예외 처리
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ApiResponse<?> handleGenericException(Exception ex) {
+        return ApiResponse.error("서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용

- `Card`, `Deck`, `Member` 등 주요 도메인에 Builder 패턴 적용 및 기본값 설정
- `CardCreateRequest`에 이미지 및 태그 리스트 추가
- 이미지 URL 저장 로직 반영
- `MemberController`에 로그인 유저 정보 조회 API (`/members/me`) 추가
- `QMember` 생성 (QueryDSL 적용)
- `GlobalExceptionHandler` 추가로 Validation, NotFound, 기타 예외 처리 일괄 대응
- 유저 인증 관련 커스텀 애노테이션 `@AuthenticatedUserMatch` 구조 준비

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요? (수동 테스트 포함)
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

---

## 🎃 새롭게 알게된 사항

- QueryDSL을 사용하는 도메인 클래스는 필드 기본값이나 관계 설정을 Builder에 명시해야 자동 생성된 Q클래스도 제대로 인식됨
- `@Builder.Default`를 사용하지 않으면 List 필드가 null로 초기화될 수 있음
- Spring `@ControllerAdvice`를 활용하면 유효성 검사 실패/EntityNotFound/예상치 못한 예외를 클린하게 통합 처리할 수 있음

---

## 📋 참고 사항

- 이미지 파일 처리는 추후 S3 업로드 로직과 연결되어야 함 (현재는 URL 리스트로 대체)
- `/members/me` 엔드포인트는 프론트엔드에서 로그인 상태 확인 또는 프로필 접근 시 활용 가능
- 예외 메시지는 프론트와 합의된 포맷으로 추후 조정 가능